### PR TITLE
Add .pgpass file for non-interactive db dump possibility

### DIFF
--- a/etc/service/postgresql/run
+++ b/etc/service/postgresql/run
@@ -41,6 +41,10 @@ if ! [[ $(ls -A "${DATADIR}" | grep -v placeholder) ]]; then
   fi
 fi
 
+# create .pgpass for automated dump
+echo "localhost:*:${PGSQL_DB_1_NAME}:${PGSQL_ROLE_1_USERNAME}:${PGSQL_ROLE_1_PASSWORD}" > ~/.pgpass
+chmod 0600 ~/.pgpass
+
 # Is there any other script to run here?
 [ -f /etc/service/postgresql/run.initialization ] && source /etc/service/postgresql/run.initialization
 


### PR DESCRIPTION
If you want to dump your database non-interactively, you have to run "pg_dump". Unfortunately, pg_dump doesn't allow to pass a password. A solution is to save your password in ~/.pgpass.

You could install pg_dump on the docker host and create .pgpass aswell, but there's chance of version incompatibility between client and server.

My solution is to provide the .pgpass file in the container itself and running this command outside of the container:

`docker exec postgresql pg_dump -h localhost -U username dbname`

It would be nice if you could implement these two lines in all your branches.